### PR TITLE
feat(tooling): add agent-state scripts for Protocol v2.1

### DIFF
--- a/scripts/agent-state.ps1
+++ b/scripts/agent-state.ps1
@@ -1,0 +1,113 @@
+param(
+    [Parameter(Mandatory=$true, Position=0)]
+    [ValidateSet("read", "write")]
+    [string]$Command,
+
+    [Parameter(ParameterSetName="read")]
+    [string]$IssueNumber,
+
+    [Parameter(ParameterSetName="write")]
+    [string]$Intent,
+
+    [Parameter(ParameterSetName="write")]
+    [string]$Step,
+
+    [Parameter(ParameterSetName="write")]
+    [int]$Progress,
+
+    [Parameter(ParameterSetName="write")]
+    [string]$Memory = "{}",
+
+    [Parameter(ParameterSetName="write")]
+    [string]$Plan,
+
+    [Parameter(ParameterSetName="write")]
+    [string]$InputRequest,
+
+    [Parameter(ParameterSetName="write")]
+    [string]$NextAction
+)
+
+function Get-AgentState {
+    param([string]$IssueId)
+
+    if (-not $IssueId) {
+        Write-Error "Issue Number is required for read command."
+        return
+    }
+
+    # Fetch comments using gh cli
+    try {
+        $commentsJson = gh issue view $IssueId --json comments
+        $comments = $commentsJson | ConvertFrom-Json
+    } catch {
+        Write-Error "Failed to fetch issue comments. Ensure gh cli is authenticated."
+        return
+    }
+
+    # Find last comment with <agent-state>
+    $lastState = $null
+    foreach ($comment in $comments.comments) {
+        if ($comment.body -match "(?s)<agent-state>(.*?)<\/agent-state>") {
+            $lastState = $Matches[1]
+        }
+    }
+
+    if (-not $lastState) {
+        Write-Warning "No <agent-state> found in issue $IssueId"
+        return
+    }
+
+    # Parse XML (Basic Regex parsing for robustness against malformed XML)
+    $state = @{}
+
+    $fields = @("intent", "step", "progress", "memory", "plan", "input_request", "next_action")
+    foreach ($field in $fields) {
+        if ($lastState -match "(?s)<$field>(.*?)<\/$field>") {
+            $state[$field] = $Matches[1].Trim()
+        }
+    }
+
+    # Handle Metrics specially if needed, or just generic parsing
+    if ($lastState -match "(?s)<metrics>(.*?)<\/metrics>") {
+        $state["metrics"] = $Matches[1].Trim()
+    }
+
+    return $state | ConvertTo-Json -Depth 5
+}
+
+function New-AgentState {
+    $xml = "<agent-state>`n"
+
+    if ($Intent) { $xml += "  <intent>$Intent</intent>`n" }
+    if ($Step) { $xml += "  <step>$Step</step>`n" }
+    if ($Progress) { $xml += "  <progress>$Progress</progress>`n" }
+
+    if ($Memory) {
+        $xml += "  <memory>`n$Memory`n  </memory>`n"
+    }
+
+    if ($Plan) {
+        $xml += "  <plan>`n$Plan`n  </plan>`n"
+    }
+
+    if ($InputRequest) {
+        $xml += "  <input_request>`n$InputRequest`n  </input_request>`n"
+    }
+
+    # Auto-generate metrics
+    $date = Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ"
+    $xml += "  <metrics>`n    <generated_at>$date</generated_at>`n  </metrics>`n"
+
+    if ($NextAction) { $xml += "  <next_action>$NextAction</next_action>`n" }
+
+    $xml += "</agent-state>"
+
+    return $xml
+}
+
+if ($Command -eq "read") {
+    Get-AgentState -IssueId $IssueNumber
+} elseif ($Command -eq "write") {
+    New-AgentState
+}

--- a/scripts/agent-state.sh
+++ b/scripts/agent-state.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+# Git-Core Protocol v2.1 - Agent State Tool (Bash)
+# Usage:
+#   ./agent-state.sh read --issue <number>
+#   ./agent-state.sh write --intent "..." --step "..." --progress 50
+
+COMMAND="$1"
+shift
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --issue) ISSUE_NUMBER="$2"; shift 2 ;;
+        --intent) INTENT="$2"; shift 2 ;;
+        --step) STEP="$2"; shift 2 ;;
+        --progress) PROGRESS="$2"; shift 2 ;;
+        --memory) MEMORY="$2"; shift 2 ;;
+        --plan) PLAN="$2"; shift 2 ;;
+        --input-request) INPUT_REQUEST="$2"; shift 2 ;;
+        --next-action) NEXT_ACTION="$2"; shift 2 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# Function to extract XML field value
+extract_field() {
+    local field="$1"
+    local content="$2"
+    echo "$content" | grep -oP "(?<=<$field>).*?(?=</$field>)" | head -1
+}
+
+# READ: Parse agent-state from issue comments
+get_agent_state() {
+    if [ -z "$ISSUE_NUMBER" ]; then
+        echo "Error: Issue number is required for read command." >&2
+        exit 1
+    fi
+
+    # Fetch comments using gh CLI
+    COMMENTS_JSON=$(gh issue view "$ISSUE_NUMBER" --json comments 2>/dev/null)
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to fetch issue comments. Ensure gh CLI is authenticated." >&2
+        exit 1
+    fi
+
+    # Find last comment with <agent-state>
+    LAST_STATE=$(echo "$COMMENTS_JSON" | jq -r '.comments[].body' | grep -oP '(?s)<agent-state>.*?</agent-state>' | tail -1)
+
+    if [ -z "$LAST_STATE" ]; then
+        echo "Warning: No <agent-state> found in issue $ISSUE_NUMBER" >&2
+        echo "{}"
+        return
+    fi
+
+    # Parse XML fields (basic regex - for robust parsing, use a proper XML tool)
+    INTENT_VAL=$(extract_field "intent" "$LAST_STATE")
+    STEP_VAL=$(extract_field "step" "$LAST_STATE")
+    PROGRESS_VAL=$(extract_field "progress" "$LAST_STATE")
+    MEMORY_VAL=$(extract_field "memory" "$LAST_STATE")
+    PLAN_VAL=$(extract_field "plan" "$LAST_STATE")
+    INPUT_REQUEST_VAL=$(extract_field "input_request" "$LAST_STATE")
+    METRICS_VAL=$(extract_field "metrics" "$LAST_STATE")
+    NEXT_ACTION_VAL=$(extract_field "next_action" "$LAST_STATE")
+
+    # Construct JSON output
+    JSON="{"
+    [ -n "$INTENT_VAL" ] && JSON="$JSON\"intent\":\"$INTENT_VAL\","
+    [ -n "$STEP_VAL" ] && JSON="$JSON\"step\":\"$STEP_VAL\","
+    [ -n "$PROGRESS_VAL" ] && JSON="$JSON\"progress\":$PROGRESS_VAL,"
+    [ -n "$MEMORY_VAL" ] && JSON="$JSON\"memory\":\"$MEMORY_VAL\","
+    [ -n "$PLAN_VAL" ] && JSON="$JSON\"plan\":\"$PLAN_VAL\","
+    [ -n "$INPUT_REQUEST_VAL" ] && JSON="$JSON\"input_request\":\"$INPUT_REQUEST_VAL\","
+    [ -n "$METRICS_VAL" ] && JSON="$JSON\"metrics\":\"$METRICS_VAL\","
+    [ -n "$NEXT_ACTION_VAL" ] && JSON="$JSON\"next_action\":\"$NEXT_ACTION_VAL\","
+
+    # Remove trailing comma and close JSON
+    JSON="${JSON%,}}"
+    echo "$JSON"
+}
+
+# WRITE: Generate agent-state XML block
+new_agent_state() {
+    echo "<agent-state>"
+    [ -n "$INTENT" ] && echo "  <intent>$INTENT</intent>"
+    [ -n "$STEP" ] && echo "  <step>$STEP</step>"
+    [ -n "$PROGRESS" ] && echo "  <progress>$PROGRESS</progress>"
+
+    if [ -n "$MEMORY" ]; then
+        echo "  <memory>"
+        echo "$MEMORY"
+        echo "  </memory>"
+    fi
+
+    if [ -n "$PLAN" ]; then
+        echo "  <plan>"
+        echo "$PLAN"
+        echo "  </plan>"
+    fi
+
+    if [ -n "$INPUT_REQUEST" ]; then
+        echo "  <input_request>"
+        echo "$INPUT_REQUEST"
+        echo "  </input_request>"
+    fi
+
+    # Auto-generate metrics
+    DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    echo "  <metrics>"
+    echo "    <generated_at>$DATE</generated_at>"
+    echo "  </metrics>"
+
+    [ -n "$NEXT_ACTION" ] && echo "  <next_action>$NEXT_ACTION</next_action>"
+    echo "</agent-state>"
+}
+
+# Main dispatch
+if [ "$COMMAND" == "read" ]; then
+    get_agent_state
+elif [ "$COMMAND" == "write" ]; then
+    new_agent_state
+else
+    echo "Usage: $0 [read|write] ..."
+    echo ""
+    echo "Commands:"
+    echo "  read --issue <number>        Read agent state from issue comments"
+    echo "  write --intent <value> ...   Generate agent-state XML block"
+    echo ""
+    echo "Write options:"
+    echo "  --intent <value>       Current intent"
+    echo "  --step <value>         Current step (planning, coding, testing, etc.)"
+    echo "  --progress <0-100>     Progress percentage"
+    echo "  --memory <json>        Memory JSON string"
+    echo "  --plan <text>          Plan items"
+    echo "  --input-request <text> Input request details"
+    echo "  --next-action <value>  Suggested next action"
+    exit 1
+fi


### PR DESCRIPTION
## Description

This PR adds the **agent-state tooling** for Git-Core Protocol v2.1.

### Changes
- **`scripts/agent-state.ps1`** (PowerShell for Windows)
- **`scripts/agent-state.sh`** (Bash for Linux/macOS)

### Features
- `read --issue <number>`: Parse the last `<agent-state>` block from issue comments and output as JSON
- `write --intent "..." --step "..." --progress N`: Generate valid XML `<agent-state>` blocks

### Usage Examples

```powershell
# Windows - Read state from issue
./scripts/agent-state.ps1 read -IssueNumber 42

# Windows - Generate state XML
./scripts/agent-state.ps1 write -Intent "implement_feature" -Step "coding" -Progress 50
```

```bash
# Linux/macOS - Read state from issue
./scripts/agent-state.sh read --issue 42

# Linux/macOS - Generate state XML
./scripts/agent-state.sh write --intent "implement_feature" --step "coding" --progress 50
```

### Checklist
- [x] PowerShell script created
- [x] Bash script created
- [x] Tested via dogfooding on Issue #42

Closes #42

---
**Note:** This replaces PR #44 which had merge conflicts due to overlapping changes with merged PRs #40 and #41.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added agent state management tools supporting read and write operations with automatic timestamp tracking and structured data formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->